### PR TITLE
Added Rule#to_s

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,38 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ["2.6", "2.7", "3.0"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+        # change this to (see https://github.com/ruby/setup-ruby#versioning):
+        # uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@2b019609e2b0f1ea1a2bc8ca11cb82ab46ada124
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: Run tests
+        run: bundle exec rspec

--- a/lib/rrule/rule.rb
+++ b/lib/rrule/rule.rb
@@ -8,12 +8,17 @@ module RRule
 
     def initialize(rrule, dtstart: Time.now, tzid: 'UTC', exdate: [], max_year: nil)
       @tz = tzid
+      @rrule = rrule
       @dtstart = dtstart.is_a?(Date) ? dtstart : floor_to_seconds_in_timezone(dtstart)
       @exdate = exdate
       @options = parse_options(rrule)
       @frequency_type = Frequency.for_options(options)
       @max_year = max_year || 9999
       @max_date = DateTime.new(@max_year)
+    end
+
+    def to_s
+      @rrule
     end
 
     def all(limit: nil)

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -2591,4 +2591,11 @@ describe RRule::Rule do
     expect(rrule.next).to eql Time.parse('Wed Sep  4 06:00:00 PDT 1997')
     expect(rrule.next).to eql Time.parse('Thu Sep  6 06:00:00 PDT 1997')
   end
+
+  it 'correctly returns the parsed rule when invoking the to_s method' do
+    rrule_string = 'RRULE:INTERVAL=2;FREQ=DAILY;COUNT=10'
+    rrule = RRule::Rule.new(rrule_string)
+
+    expect(rrule.to_s).to eql rrule_string
+  end
 end


### PR DESCRIPTION
There wasn't a way to retrieve the original rrule string used for instantiating the `RRule`. This change introduces the ability of retrieving it by calling the `to_s` method (which previously only returned `"RRule::Rule"`)

I also opted for using the `to_s` to "match" how they do it in the [RRULE library implemented in javascript](https://github.com/jakubroztocil/rrule):
![image](https://user-images.githubusercontent.com/19315023/206339583-0ec29a53-3e77-4017-a881-3ef65ded2475.png)